### PR TITLE
Fix tab behavior

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1,3 +1,19 @@
+/**
+ * Returns true if targetNode appears after sourceNode in the dom.
+ * @param {HTMLElement} sourceNode - the source node for comparison
+ * @param {HTMLElement} targetNode - the node to compare against sourceNode
+ */
+function isAfter(sourceNode, targetNode) {
+	if (!sourceNode) {
+		throw new TypeError('Source node is missing or undefined');
+	}
+
+	return !!(
+		targetNode &&
+		sourceNode.compareDocumentPosition(targetNode) & Node.DOCUMENT_POSITION_PRECEDING
+	);
+}
+
 (function ($) {
 
 	// default player values
@@ -339,12 +355,20 @@
 							// if user clicks on the Play/Pause button in the control bar once it attempts
 							// to hide it
 							if (!t.hasMsNativeFullScreen) {
-								var playButton = t.container.find('.mejs-playpause-button > button');
-								playButton.focus();
+								// If e.relatedTarget appears before container, send focus to play button,
+								// else send focus to last control button.
+								var btnSelector = '.mejs-playpause-button > button';
+
+								if (isAfter(e.relatedTarget, t.container[0])) {
+									btnSelector = '.mejs-controls .mejs-button:last-child > button';
+								}
+
+								var button = t.container.find(btnSelector);
+								button.focus();
 							}
 						}
 					});
- 
+
 				if (t.options.stretching === 'fill' && !t.container.parent('mejs-fill-container').length) {
 					// outer container
 					t.outerContainer = t.$media.parent();


### PR DESCRIPTION
There is a limitation at the moment where i focus the fullscreen button even though that feature may not be enabled. It meets our use case, but something to think about in the future would be to focus the right most control that is enabled.

_ignore build files_
