### PR TITLE
[A11y] Make the sourcechooser keyboard-friendly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,7 @@ module.exports = function(grunt) {
                     'src/js/mep-feature-fullscreen.js',
                     'src/js/mep-feature-speed.js',
                     'src/js/mep-feature-tracks.js',
+                    'src/js/mep-feature-sourcechooser.js',
                     'src/js/mep-feature-contextmenu.js',
                     'src/js/mep-feature-skipback.js',
                     'src/js/mep-feature-postroll.js'

--- a/demo/mediaelementplayer-sourcechooser.html
+++ b/demo/mediaelementplayer-sourcechooser.html
@@ -6,7 +6,7 @@
 
 
 	<script src="../build/jquery.js"></script>
-	<script src="../build/mediaelement-and-player.min.js"></script>
+	<script src="../build/mediaelement-and-player.js"></script>
 	<script src="testforfiles.js"></script>	
 	<link rel="stylesheet" href="../build/mediaelementplayer.min.css" />
 </head>
@@ -27,7 +27,8 @@
 
 <script>
 $('audio,video').mediaelementplayer({
-	features: ['playpause','progress','volume','sourcechooser']
+  keyActions: [], // disable global key bindings to allow sourcechooser keyboard navigation
+	features: ['playpause', 'progress', 'sourcechooser']
 });
 </script>
 

--- a/demo/mediaelementplayer-sourcechooser.html
+++ b/demo/mediaelementplayer-sourcechooser.html
@@ -6,7 +6,7 @@
 
 
 	<script src="../build/jquery.js"></script>
-	<script src="../build/mediaelement-and-player.js"></script>
+	<script src="../build/mediaelement-and-player.min.js"></script>
 	<script src="testforfiles.js"></script>	
 	<link rel="stylesheet" href="../build/mediaelementplayer.min.css" />
 </head>
@@ -28,7 +28,7 @@
 <script>
 $('audio,video').mediaelementplayer({
   keyActions: [], // disable global key bindings to allow sourcechooser keyboard navigation
-	features: ['playpause', 'progress', 'sourcechooser']
+	features: ['playpause','progress','volume','sourcechooser']
 });
 </script>
 

--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -817,7 +817,6 @@
 }
 
 .mejs-controls .mejs-sourcechooser-button .mejs-sourcechooser-selector {
-	visibility: hidden;
 	position: absolute;
 	bottom: 26px;
 	right: -10px;

--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -12,23 +12,57 @@
 
 			player.sourcechooserButton =
 				$('<div class="mejs-button mejs-sourcechooser-button">'+
-					'<button type="button" aria-controls="' + t.id + '" title="' + t.options.sourcechooserText + '" aria-label="' + t.options.sourcechooserText + '"></button>'+
-					'<div class="mejs-sourcechooser-selector mejs-offscreen">'+
-						'<ul>'+
-						'</ul>'+
-					'</div>'+
-				'</div>')
+						'<button type="button" aria-haspopup="true" aria-owns="' + t.id + '" title="' + t.options.sourcechooserText + '" aria-label="' + t.options.sourcechooserText + '"></button>'+
+						'<div class="mejs-sourcechooser-selector mejs-offscreen" role="menu" aria-expanded="false" aria-hidden="true">'+
+							'<ul>'+
+							'</ul>'+
+						'</div>'+
+					'</div>')
 					.appendTo(controls)
 
 					// hover
 					.hover(function() {
-						$(this).find('.mejs-sourcechooser-selector').removeClass('mejs-offscreen');
+						$(this).find('.mejs-sourcechooser-selector')
+							.removeClass('mejs-offscreen')
+							.attr('aria-expanded', 'true')
+							.attr('aria-hidden', 'false');
 					}, function() {
-						$(this).find('.mejs-sourcechooser-selector').addClass('mejs-offscreen');
+						$(this).find('.mejs-sourcechooser-selector')
+							.addClass('mejs-offscreen')
+							.attr('aria-expanded', 'false')
+							.attr('aria-hidden', 'true');
 					})
 
-					// handle clicks to the language radio buttons
+					// keyboard menu activation
+					.on('keydown', function (e) {
+					  var keyCode = e.keyCode;
+
+					  switch (keyCode) {
+							case 32: // space
+								$(this).find('.mejs-sourcechooser-selector')
+									.removeClass('mejs-offscreen')
+									.attr('aria-expanded', 'true')
+									.attr('aria-hidden', 'false')
+									.find('input[type=radio]:checked').first().focus();
+								break;
+							case 27: // esc
+								$(this).find('.mejs-sourcechooser-selector')
+									.addClass('mejs-offscreen')
+									.attr('aria-expanded', 'false')
+									.attr('aria-hidden', 'true');
+								$(this).find('button').focus();
+								break;
+							default:
+								return true;
+								}
+							})
+
+					// handle clicks to the source radio buttons
 					.delegate('input[type=radio]', 'click', function() {
+						// set aria states
+						$(this).attr('aria-selected', true).attr('checked', 'checked');
+						$(this).closest('.mejs-sourcechooser-selector').find('input[type=radio]').not(this).attr('aria-selected', 'false').removeAttr('checked');
+
 						var src = this.value;
 
 						if (media.currentSrc != src) {
@@ -71,9 +105,9 @@
 
 			t.sourcechooserButton.find('ul').append(
 				$('<li>'+
-					'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + type + '" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + ' />'+
-					'<label for="' + t.id + '_sourcechooser_' + label + type + '">' + label + ' (' + type + ')</label>'+
-				'</li>')
+						'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + type + '" role="menuitemradio" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + 'aria-selected="' + isCurrent + '"' + ' />'+
+						'<label for="' + t.id + '_sourcechooser_' + label + type + '">' + label + ' (' + type + ')</label>'+
+					'</li>')
 			);
 
 			t.adjustSourcechooserBox();


### PR DESCRIPTION
- adds aria roles and states to the menu and menu-items
- allows keyboard-only operation
