### PR TITLE
[A11y] Make the sourcechooser SR-friendly

### DIFF
--- a/src/js/me-utility.js
+++ b/src/js/me-utility.js
@@ -258,5 +258,21 @@ mejs.Utility = {
             return url.substr(0, url.indexOf("://")+3);
         }
         return "//"; // let user agent figure this out
-    }
+    },
+
+	// taken from underscore
+	debounce: function(func, wait, immediate) {
+		var timeout;
+		return function() {
+			var context = this, args = arguments;
+			var later = function() {
+				timeout = null;
+				if (!immediate) func.apply(context, args);
+			};
+			var callNow = immediate && !timeout;
+			clearTimeout(timeout);
+			timeout = setTimeout(later, wait);
+			if (callNow) func.apply(context, args);
+		};
+	}
 };

--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -32,11 +32,6 @@
 						}, 500);
 					})
 
-					// Handle click so that screen readers can open the menu
-					.click(function (e) {
-						player.showSourcechooserSelector();
-					})
-
 					// keyboard menu activation
 					.on('keydown', function (e) {
 						var keyCode = e.keyCode;
@@ -64,17 +59,17 @@
 							})
 
 					// close menu when tabbing away
-					.on('focusout', function (e) {
+					.on('focusout', mejs.Utility.debounce(function (e) { // Safari triggers focusout multiple times
 						// Firefox does NOT support e.relatedTarget to see which element
 						// just lost focus, so wait to find the next focused element
 						setTimeout(function () {
 							var parent = $(document.activeElement).closest('.mejs-sourcechooser-selector');
-							if (!parent.length && !parent.find('.mejs-sourcechooser-selector').hasClass('mejs-offscreen')) {
-								// focus is outside the control, but the menu is visible; close it
+							if (!parent.length) {
+								// focus is outside the control; close menu
 								player.hideSourcechooserSelector();
 							}
 						}, 0);
-					})
+					}, 100))
 
 					// handle clicks to the source radio buttons
 					.delegate('input[type=radio]', 'click', function() {
@@ -103,7 +98,17 @@
 							media.addEventListener('canplay', canPlayAfterSourceSwitchHandler, true);
 							media.load();
 						}
-				});
+					})
+
+					// Handle click so that screen readers can toggle the menu
+					.delegate('button', 'click', function (e) {
+						if ($(this).siblings('.mejs-sourcechooser-selector').hasClass('mejs-offscreen')) {
+							player.showSourcechooserSelector();
+							$(this).siblings('.mejs-sourcechooser-selector').find('input[type=radio]:checked').first().focus();
+						} else {
+							player.hideSourcechooserSelector();
+						}
+					});
 
 			// add to list
 			for (var i in this.node.children) {
@@ -124,7 +129,7 @@
 			t.sourcechooserButton.find('ul').append(
 				$('<li>'+
 						'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + type + '" role="menuitemradio" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + 'aria-selected="' + isCurrent + '"' + ' />'+
-						'<label for="' + t.id + '_sourcechooser_' + label + type + '">' + label + ' (' + type + ')</label>'+
+						'<label for="' + t.id + '_sourcechooser_' + label + type + '" aria-hidden="true">' + label + ' (' + type + ')</label>'+
 					'</li>')
 			);
 
@@ -155,7 +160,7 @@
 				.attr('aria-expanded', 'true')
 				.attr('aria-hidden', 'false')
 				.find('input[type=radio]')
-				.removeAttr('tabindex');
+				.attr('tabindex', '0');
 		}
 	});
 

--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -13,7 +13,7 @@
 
 			player.sourcechooserButton =
 				$('<div class="mejs-button mejs-sourcechooser-button">'+
-						'<button type="button" aria-haspopup="true" aria-owns="' + t.id + '" title="' + t.options.sourcechooserText + '" aria-label="' + t.options.sourcechooserText + '"></button>'+
+						'<button type="button" role="button" aria-haspopup="true" aria-owns="' + t.id + '" title="' + t.options.sourcechooserText + '" aria-label="' + t.options.sourcechooserText + '"></button>'+
 						'<div class="mejs-sourcechooser-selector mejs-offscreen" role="menu" aria-expanded="false" aria-hidden="true">'+
 							'<ul>'+
 							'</ul>'+
@@ -40,10 +40,11 @@
 
 					// keyboard menu activation
 					.on('keydown', function (e) {
-					  var keyCode = e.keyCode;
+						var keyCode = e.keyCode;
 
-					  switch (keyCode) {
+						switch (keyCode) {
 							case 32: // space
+							case 13: // enter
 								$(this).find('.mejs-sourcechooser-selector')
 									.removeClass('mejs-offscreen')
 									.attr('aria-expanded', 'true')
@@ -61,6 +62,18 @@
 								return true;
 								}
 							})
+
+					// close menu when tabbing away
+					.on('focusout', function (e) {
+						var parent = $(e.relatedTarget).closest('.mejs-sourcechooser-button');
+						if (!parent.length && !parent.find('.mejs-sourcechooser-selector').hasClass('mejs-offscreen')) {
+							// focus is outside the control, but the menu is visible; close it
+							player.sourcechooserButton.find('.mejs-sourcechooser-selector')
+								.addClass('mejs-offscreen')
+								.attr('aria-expanded', 'false')
+								.attr('aria-hidden', 'true');
+						}
+					})
 
 					// handle clicks to the source radio buttons
 					.delegate('input[type=radio]', 'click', function() {
@@ -98,7 +111,6 @@
 					player.addSourceButton(src.src, src.title, src.type, media.src == src.src);
 				}
 			}
-
 		},
 
 		addSourceButton: function(src, label, type, isCurrent) {

--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -24,18 +24,17 @@
 					// hover
 					.hover(function() {
 						clearTimeout(hoverTimeout);
-						$(this).find('.mejs-sourcechooser-selector')
-							.removeClass('mejs-offscreen')
-							.attr('aria-expanded', 'true')
-							.attr('aria-hidden', 'false');
+						player.showSourcechooserSelector();
 					}, function() {
 						var self = $(this);
 						hoverTimeout = setTimeout(function () {
-							self.find('.mejs-sourcechooser-selector')
-								.addClass('mejs-offscreen')
-								.attr('aria-expanded', 'false')
-								.attr('aria-hidden', 'true');
+						player.hideSourcechooserSelector();
 						}, 500);
+					})
+
+					// Handle click so that screen readers can open the menu
+					.click(function (e) {
+						player.showSourcechooserSelector();
 					})
 
 					// keyboard menu activation
@@ -45,17 +44,12 @@
 						switch (keyCode) {
 							case 32: // space
 							case 13: // enter
+								player.showSourcechooserSelector();
 								$(this).find('.mejs-sourcechooser-selector')
-									.removeClass('mejs-offscreen')
-									.attr('aria-expanded', 'true')
-									.attr('aria-hidden', 'false')
 									.find('input[type=radio]:checked').first().focus();
 								break;
 							case 27: // esc
-								$(this).find('.mejs-sourcechooser-selector')
-									.addClass('mejs-offscreen')
-									.attr('aria-expanded', 'false')
-									.attr('aria-hidden', 'true');
+								player.hideSourcechooserSelector();
 								$(this).find('button').focus();
 								break;
 							default:
@@ -68,10 +62,7 @@
 						var parent = $(e.relatedTarget).closest('.mejs-sourcechooser-button');
 						if (!parent.length && !parent.find('.mejs-sourcechooser-selector').hasClass('mejs-offscreen')) {
 							// focus is outside the control, but the menu is visible; close it
-							player.sourcechooserButton.find('.mejs-sourcechooser-selector')
-								.addClass('mejs-offscreen')
-								.attr('aria-expanded', 'false')
-								.attr('aria-hidden', 'true');
+							player.hideSourcechooserSelector();
 						}
 					})
 
@@ -137,6 +128,24 @@
 			t.sourcechooserButton.find('.mejs-sourcechooser-selector').height(
 				t.sourcechooserButton.find('.mejs-sourcechooser-selector ul').outerHeight(true)
 			);
+		},
+
+		hideSourcechooserSelector: function () {
+			this.sourcechooserButton.find('.mejs-sourcechooser-selector')
+				.addClass('mejs-offscreen')
+				.attr('aria-expanded', 'false')
+				.attr('aria-hidden', 'true')
+				.find('input[type=radio]') // make radios not fucusable
+				.attr('tabindex', '-1');
+		},
+
+		showSourcechooserSelector: function () {
+			this.sourcechooserButton.find('.mejs-sourcechooser-selector')
+				.removeClass('mejs-offscreen')
+				.attr('aria-expanded', 'true')
+				.attr('aria-hidden', 'false')
+				.find('input[type=radio]')
+				.removeAttr('tabindex');
 		}
 	});
 

--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -43,6 +43,12 @@
 
 						switch (keyCode) {
 							case 32: // space
+								if (!mejs.MediaFeatures.isFirefox) { // space sends the click event in Firefox
+									player.showSourcechooserSelector();
+								}
+								$(this).find('.mejs-sourcechooser-selector')
+									.find('input[type=radio]:checked').first().focus();
+								break;
 							case 13: // enter
 								player.showSourcechooserSelector();
 								$(this).find('.mejs-sourcechooser-selector')
@@ -59,11 +65,15 @@
 
 					// close menu when tabbing away
 					.on('focusout', function (e) {
-						var parent = $(e.relatedTarget).closest('.mejs-sourcechooser-button');
-						if (!parent.length && !parent.find('.mejs-sourcechooser-selector').hasClass('mejs-offscreen')) {
-							// focus is outside the control, but the menu is visible; close it
-							player.hideSourcechooserSelector();
-						}
+						// Firefox does NOT support e.relatedTarget to see which element
+						// just lost focus, so wait to find the next focused element
+						setTimeout(function () {
+							var parent = $(document.activeElement).closest('.mejs-sourcechooser-selector');
+							if (!parent.length && !parent.find('.mejs-sourcechooser-selector').hasClass('mejs-offscreen')) {
+								// focus is outside the control, but the menu is visible; close it
+								player.hideSourcechooserSelector();
+							}
+						}, 0);
 					})
 
 					// handle clicks to the source radio buttons


### PR DESCRIPTION
- VO + Ctrl+Option+Spc opens selector
- Enter or Space opens the selector
- Tab away hides selector
