### PR TITLE
[A11y] make SRs read option labels out loud

### DIFF
--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -147,7 +147,7 @@
 
 			t.sourcechooserButton.find('ul').append(
 				$('<li>'+
-						'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + type + '" role="menuitemradio" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + 'aria-selected="' + isCurrent + '"' + ' />'+
+						'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + type + '" role="menuitemradio" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + 'aria-selected="' + isCurrent + '" aria-label="' + label + '"' + ' />'+
 						'<label for="' + t.id + '_sourcechooser_' + label + type + '" aria-hidden="true">' + label + ' (' + type + ')</label>'+
 					'</li>')
 			);

--- a/src/js/mep-feature-speed.js
+++ b/src/js/mep-feature-speed.js
@@ -73,7 +73,7 @@
 				}
 
 				var html = '<div class="mejs-button mejs-speed-button">' +
-							'<button role="button" aria-haspopup="true" aria-controls="' + t.id + '" type="button" aria-label="' + speedLabel(t.options.defaultSpeed) + '">' + getSpeedNameFromValue(t.options.defaultSpeed) + '</button>' +
+							'<button role="button" aria-haspopup="true" aria-controls="' + t.id + '" type="button" aria-label="' + speedLabel(t.options.defaultSpeed) + '" aria-live="assertive">' + getSpeedNameFromValue(t.options.defaultSpeed) + '</button>' +
 							'<div class="mejs-speed-selector mejs-offscreen" role="menu" aria-expanded="false" aria-hidden="true">' +
 							'<ul>';
 
@@ -86,6 +86,7 @@
 											'id="' + inputId + '" ' +
 											(isCurrent ? ' checked="checked"' : '') +
 											' aria-selected="' + isCurrent + '"' +
+											' aria-label="' + getSpeedNameFromValue(speeds[i].value) + '"' +
 											' />' +
 								'<label for="' + inputId + '" ' + 'aria-hidden="true"' +
 											(isCurrent ? ' class="mejs-speed-selected"' : '') +


### PR DESCRIPTION
Missed these when updating the speed and quality menus
