### PR TITLE
improve keyboard accessibility for vertical volume slider

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -431,7 +431,6 @@
 }
 
 .mejs-controls .mejs-volume-button .mejs-volume-slider {
-	display: none;
 	height: 115px;
 	width: 25px;
 	background: url("background.png");


### PR DESCRIPTION
since the mute button has a separate function from just opening the
vertical volume slider, we open the slider automatically on focus and
add it to the tab order, hiding it again when you focus away.